### PR TITLE
Disable the numberDisplayed option with a value of -1 instead of 0

### DIFF
--- a/dist/js/bootstrap-multiselect.js
+++ b/dist/js/bootstrap-multiselect.js
@@ -268,7 +268,7 @@
                         return this.allSelectedText;
                     }
                 }
-                else if (this.numberDisplayed != 0 && options.length > this.numberDisplayed) {
+                else if (this.numberDisplayed != -1 && options.length > this.numberDisplayed) {
                     return options.length + ' ' + this.nSelectedText;
                 }
                 else {

--- a/index.html
+++ b/index.html
@@ -861,7 +861,7 @@ $(document).ready(function() {
                                     <p>This option will collapse all <code>optgroup</code>s by default.</p>
 
                                     <p class="alert alert-info">There is also an example in the <a href="#further-examples">Further Examples</a> section demonstrating an alternative way of collapsing <code>optgroups</code> by default.</a></p>
-                                
+
                                     <div class="example">
                                             <script type="text/javascript">
                                                 $(document).ready(function() {
@@ -2083,7 +2083,7 @@ $(document).ready(function() {
                                         This option is used by the <code>buttonText</code> and <code>buttonTitle</code> functions to determine if too many options would be displayed.
                                     </p>
 
-                                    <p class="alert alert-info">The functionality can be disabled by setting <code>numberDisplayed</code> to <code>0</code>.</p>
+                                    <p class="alert alert-info">The functionality can be disabled by setting <code>numberDisplayed</code> to <code>-1</code>.</p>
 
                                     <div class="example">
                                         <script type="text/javascript">
@@ -6146,7 +6146,7 @@ $(document).ready(function() {
                                 $(window).scroll(function() {
                                     var top = $('#example-automatic-dropup-container')[0].getBoundingClientRect().top
                                     var bottom = $(window).height() - top - $('#example-automatic-dropup-container').height();
-                                    
+
                                     if (bottom < 250) {
                                         $('#example-automatic-dropup-container').addClass('dropup');
                                     }

--- a/types/bootstrap-multiselect/index.d.ts
+++ b/types/bootstrap-multiselect/index.d.ts
@@ -37,9 +37,9 @@ interface MultiSelectOptions {
 
     /**
      * If set to true, optgroup's will be clickable, allowing to easily select multiple options belonging to the same group.
-     * 
+     *
      * enableClickableOptGroups is not available in single selection mode, i.e. when the multiple attribute is not present.
-     * 
+     *
      * When using selectedClass, the selected classes are also applied on the option groups.
      */
     enableClickableOptGroups?: boolean;
@@ -54,9 +54,9 @@ interface MultiSelectOptions {
      */
     disableIfEmpty?: boolean;
 
-    /** 
-     * The text shown if the multiselect is disabled. 
-     * Note that this option is set to the empty string '' by default, 
+    /**
+     * The text shown if the multiselect is disabled.
+     * Note that this option is set to the empty string '' by default,
      * that is nonSelectedText is shown if the multiselect is disabled and no options are selected.
      */
     disabledText?: string;
@@ -78,13 +78,13 @@ interface MultiSelectOptions {
     maxHeight?: number;
 
     /**
-     * The name used for the generated checkboxes. 
+     * The name used for the generated checkboxes.
      * See {@link https://davidstutz.github.io/bootstrap-multiselect/#post|Server-Side Processing} for details.
      */
     checkboxName?: string;
 
     /**
-     * A function which is triggered on the change event of the options. 
+     * A function which is triggered on the change event of the options.
      * Note that the event is not triggered when selecting or deselecting options using the select and deselect methods provided by the plugin.
      * @param option The option item that was changed, wrapped in a JQuery object.
      * @param checked Whether the checkbox was checked or not.
@@ -98,36 +98,36 @@ interface MultiSelectOptions {
 
     /**
      * A callback called when the dropdown is shown.
-     * 
+     *
      * The onDropdownShow option is not available when using Twitter Bootstrap 2.3.
      */
     onDropdownShow?: (event: Event) => void;
 
     /**
      * A callback called when the dropdown is closed.
-     * 
+     *
      * The onDropdownHide option is not available when using Twitter Bootstrap 2.3.
      */
     onDropdownHide?: (event: Event) => void;
 
     /**
      * A callback called after the dropdown has been shown.
-     * 
+     *
      * The onDropdownShown option is not available when using Twitter Bootstrap 2.3.
      */
     onDropdownShown?: (event: Event) => void;
 
     /**
      * A callback called after the dropdown has been closed.
-     * 
+     *
      * The onDropdownHidden option is not available when using Twitter Bootstrap 2.3.
      */
     onDropdownHidden?: (event: Event) => void;
 
     /**
      * The class of the multiselect button.
-     * 
-     * @example 
+     *
+     * @example
      * $('#example-buttonClass').multiselect({
             buttonClass: 'btn btn-link'
         });
@@ -141,8 +141,8 @@ interface MultiSelectOptions {
 
     /**
      * The container holding both the button as well as the dropdown.
-     * 
-     * @example 
+     *
+     * @example
      * $('#example-buttonContainer').multiselect({
             buttonContainer: '<div class="btn-group" />'
         });
@@ -151,10 +151,10 @@ interface MultiSelectOptions {
 
     /**
      * The width of the multiselect button may be fixed using this option.
-     * 
+     *
      * Actually, buttonWidth describes the width of the .btn-group container and the width of the button is set to 100%.
-     * 
-     * @example  
+     *
+     * @example
      * $('#example-buttonWidth').multiselect({
             buttonWidth: '400px'
         });
@@ -169,9 +169,9 @@ interface MultiSelectOptions {
      * {@link nSelectedText} in the case more than {@link numberDisplayed} options are selected
      * and the names of the selected options if less than {@link numberDisplayed} options are selected.
 
-     * @param options 
-     * @param select 
-     * @returns {} 
+     * @param options
+     * @param select
+     * @returns {}
      */
     buttonText?: (options: HTMLOptionsCollection, select: HTMLSelectElement) => string;
 
@@ -183,8 +183,8 @@ interface MultiSelectOptions {
      * If more than numberDisplayed options are selected, {@link nSelectedText} is returned.
      *
      * @param options
-     * @param select 
-     * @returns {} 
+     * @param select
+     * @returns {}
     */
     buttonTitle?: (options: HTMLOptionElement[], select: HTMLSelectElement) => string;
 
@@ -204,7 +204,7 @@ interface MultiSelectOptions {
     allSelectedText?: string | boolean;
 
     /**
-     * This option is used by the buttonText and buttonTitle functions to determine of too much options would be displayed.
+     * This option is used by the buttonText and buttonTitle functions to determine if too many options would be displayed.
      */
     numberDisplayed?: number;
 
@@ -234,7 +234,7 @@ interface MultiSelectOptions {
     includeSelectAllOption?: boolean;
 
     /**
-     * Setting both {@link includeSelectAllOption} and {@link enableFiltering} to true, the select all option does always select only the visible option. 
+     * Setting both {@link includeSelectAllOption} and {@link enableFiltering} to true, the select all option does always select only the visible option.
      * With setting selectAllJustVisible to false this behavior is changed such that always all options (irrespective of whether they are visible) are selected.
      */
     selectAllJustVisible?: boolean;
@@ -257,28 +257,28 @@ interface MultiSelectOptions {
     selectAllName?: string;
 
     /**
-     * If set to true (default), the number of selected options will be shown in parantheses when all options are seleted. 
+     * If set to true (default), the number of selected options will be shown in parantheses when all options are seleted.
      */
     selectAllNumber?: boolean;
 
     /**
-     * This function is triggered when the select all option is used to select all options. 
+     * This function is triggered when the select all option is used to select all options.
      * Note that this can also be triggered manually using the {@link .multiselect('selectAll')} method.
-     * 
+     *
      * Note that the onChange option is not triggered when (de)selecting all options using the select all option.
-     * 
-     * The onSelectAll option is only triggered if the select all option was checked; 
+     *
+     * The onSelectAll option is only triggered if the select all option was checked;
      * it is not triggered if all options were checked manually (causing the select all option to be checked as well).
      */
     onSelectAll?: () => void;
 
     /**
-     * This function is triggered when the select all option is used to deselect all options. 
+     * This function is triggered when the select all option is used to deselect all options.
      * Note that this can also be triggered manually using the {@link .multiselect('deselectAll')} method.
-     * 
+     *
      * Note that the onChange option is not triggered when (de)selecting all options using the select all option.
-     * 
-     * The onDeselectAll option is only triggered if the select all option was unchecked; 
+     *
+     * The onDeselectAll option is only triggered if the select all option was unchecked;
      * it is not triggered if all options were unchecked manually (causing the select all option to be unchecked as well).
      */
     onDeselectAll?: () => void;
@@ -289,13 +289,13 @@ interface MultiSelectOptions {
     enableFiltering?: boolean;
 
     /**
-     * The filter as configured above will use case sensitive filtering, 
+     * The filter as configured above will use case sensitive filtering,
      * by setting enableCaseInsensitiveFiltering to true this behavior can be changed to use case insensitive filtering.
      */
     enableCaseInsensitiveFiltering?: boolean;
 
     /**
-     * Set to true to enable full value filtering, that is all options are shown where the query is a prefix of. 
+     * Set to true to enable full value filtering, that is all options are shown where the query is a prefix of.
      */
     enableFullValueFiltering?: boolean;
 
@@ -314,7 +314,7 @@ interface MultiSelectOptions {
     filterPlaceholder?: string;
 
     /**
-     * The generated HTML markup can be controlled using templates. Basically, templates are simple configuration options. 
+     * The generated HTML markup can be controlled using templates. Basically, templates are simple configuration options.
      */
     templates?: Templates;
 }
@@ -328,8 +328,8 @@ interface JQuery {
     multiselect(method: 'destroy'): JQuery;
 
     /**
-     * This method is used to refresh the checked checkboxes based on the currently selected options within the select. 
-     * Click 'Select some options' to select some of the options. Then click refresh. 
+     * This method is used to refresh the checked checkboxes based on the currently selected options within the select.
+     * Click 'Select some options' to select some of the options. Then click refresh.
      * The plugin will update the checkboxes accordingly.
      */
     multiselect(method: 'refresh'): JQuery;
@@ -352,29 +352,29 @@ interface JQuery {
     multiselect(method: 'deselect', value: string | Array<string> | number, triggerOnChange?: boolean): JQuery;
 
     /**
-     * Selects all options. 
-     * @param justVisible If set to true or not provided, all visible options are selected (when using the filter), 
+     * Selects all options.
+     * @param justVisible If set to true or not provided, all visible options are selected (when using the filter),
      * otherwise (justVisible set to false) all options are selected.
      */
     multiselect(method: 'selectAll', justVisible?: boolean): JQuery;
 
     /**
-     * Deselects all options. 
-     * @param justVisible If set to true or not provided, all visible options are deselected,  
+     * Deselects all options.
+     * @param justVisible If set to true or not provided, all visible options are deselected,
      * otherwise (justVisible set to false) all options are deselected.
      */
     multiselect(method: 'deselectAll', justVisible?: boolean): JQuery;
 
     /**
      * When manually selecting/deselecting options and the corresponding checkboxes, this function updates the text and title of the button.
-     * 
+     *
      * Note that usually this method is only needed when using .multiselect('selectAll', justVisible) or .multiselect('deselectAll', justVisible). In all other cases, .multiselect('refresh') should be used.
      */
     multiselect(method: 'updateButtonText'): JQuery;
 
     /**
      * Used to change configuration after initializing the multiselect. This may be useful in combination with {@link multiselect('rebuild')}.
-     * @example  
+     * @example
      * $('#example-setOptions').multiselect('setOptions', options);
      * $('#example-setOptions').multiselect('rebuild');
      */


### PR DESCRIPTION
Supports a use case in which the dropdown should display the number of selected options and never the options themselves. In my case, I have some long option text that would cause the multiselect to overlap with another element on the page even if only one option is selected.